### PR TITLE
openapi_utils: don't panic when components are not in spec file

### DIFF
--- a/openapi_utils/README.md
+++ b/openapi_utils/README.md
@@ -12,12 +12,12 @@ This crate provides a `deref_all` method on the `openapiv3::OpenAPI` data type. 
 
 ### Example
 
-```
+```rust
 use openapi_utils::SpecExt;
 
 pub fn read<P: AsRef<Path>>(filename: P) -> openapiv3::OpenAPI {
     let data = std::fs::read_to_string(filename).expect("OpenAPI file could not be read.");
-    serde_yaml::from_str(&data).expect("Could not deserialize file as OpenAPI v3.0 yaml");
+    serde_yaml::from_str(&data).expect("Could not deserialize file as OpenAPI v3.0 yaml")
 }
 
 let spec = read(filename).deref_all();

--- a/openapi_utils/src/dereferer.rs
+++ b/openapi_utils/src/dereferer.rs
@@ -17,7 +17,7 @@ pub trait SpecExt {
     /// references have been resolved ahead of time.
     ///
     /// # Panics
-    /// This method will panic if there are no `components` in the OpenAPI description.
+    /// This method will panic if the referenced item is not present in the OpenAPI description.
     /// This method will panic AdditionalProperties
     ///
     /// # Example
@@ -35,10 +35,8 @@ impl SpecExt for OpenAPI {
     /// Dereferences all the internal references in a document by copying
     /// the items in the place of the references.
     fn deref_all(mut self) -> OpenAPI {
-        let components = self
-            .components
-            .as_ref()
-            .expect("Dereferenciation needs `components` to be present in the file.");
+        let mut components = &Components::default();
+        self.components.as_ref().map(|comp| components = comp);
 
         for (_, path_item) in &mut self.paths {
             deref_everything_in_path(path_item, &components);


### PR DESCRIPTION
Now the panic is postponed to the point when the item is accessed (`set_deref`). 
Sorry if it is not the most idiomatic (I'm still learning). I tried to use `unwrap_or_default` on the components, however, I was told (by the compiler :smiley:) that `Default` trait is only implemented for `Components` and not `&Components`.

closes #1 