### PR TITLE
Fix to not call `unwrap` on `media.schema` if it is None

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openapi_utils"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "http 1.0.0",
  "indexmap 2.1.0",

--- a/openapi_utils/CHANGELOG.md
+++ b/openapi_utils/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.6.1
+- Fix to not call `unwrap` on `media.schema` if it is None
+
 # 0.6.0
 - Use openapiv3 2.0
 - Support oneOf, anyOf, allOf

--- a/openapi_utils/Cargo.toml
+++ b/openapi_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openapi_utils"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Jordi Polo <mumismo@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/openapi_utils/src/dereferer.rs
+++ b/openapi_utils/src/dereferer.rs
@@ -65,6 +65,9 @@ fn deref_everything_in_path(path_item: &mut ReferenceOr<PathItem>, components: &
             set_deref(req_body, &components.request_bodies, &mut Vec::new());
             let body: &mut RequestBody = req_body.to_item_mut();
             for (_, media) in &mut body.content {
+                if media.schema.is_none() {
+                    continue;
+                }
                 let schema = media.schema.as_mut().unwrap();
                 let mut referred = Vec::new();
                 set_deref(schema, &components.schemas, &mut referred);
@@ -79,6 +82,9 @@ fn deref_everything_in_path(path_item: &mut ReferenceOr<PathItem>, components: &
                 set_deref(header, &components.headers, &mut Vec::new());
             }
             for (_, media) in &mut response.to_item_mut().content {
+                if media.schema.is_none() {
+                    continue;
+                }
                 let schema = media.schema.as_mut().unwrap();
                 let mut referred = Vec::new();
                 set_deref(schema, &components.schemas, &mut referred);


### PR DESCRIPTION
This PR will suppress panicking on OpenAPI spec which has a part like this: 
```yaml
      responses:
        '200':
          description: Successfully logged out.
          content:
            application/json:
              example:
                message: Successfully logged out.
```

```
thread 'main' panicked at /oas_proxy/openapi_utils/src/dereferer.rs:82:52:
called `Option::unwrap()` on a `None` value
```

@JordiPolo 